### PR TITLE
Remove bottom padding

### DIFF
--- a/src/components/field/index.js
+++ b/src/components/field/index.js
@@ -129,7 +129,7 @@ export default class TextField extends PureComponent {
     input: 8,
     left: 0,
     right: 0,
-    bottom: 8,
+    bottom: 0,
   };
 
   static labelOffset = {


### PR DESCRIPTION
**Why**
There's a space below the textfield that may cause unexpected looks & feels.
<img width="161" alt="Screen Shot 2022-04-06 at 11 25 16" src="https://user-images.githubusercontent.com/3013321/161895546-66275fc1-3e63-4fac-b8b3-9f8ba8d6855e.png">

**Solution**
By default, set that bottom contentInset = 0.
If we want a space, we can set margin for this TextField instead

**Result**
<img width="151" alt="Screen Shot 2022-04-06 at 11 25 35" src="https://user-images.githubusercontent.com/3013321/161895582-84573f1e-f3dd-4e63-9b54-bbc23b99a460.png">

